### PR TITLE
feat: reusable Input component

### DIFF
--- a/src/app/shared/input/input.component.html
+++ b/src/app/shared/input/input.component.html
@@ -1,0 +1,1 @@
+<p>input works!</p>

--- a/src/app/shared/input/input.component.html
+++ b/src/app/shared/input/input.component.html
@@ -1,1 +1,14 @@
-<p>input works!</p>
+<input
+  pInputText
+  [type]="type"
+  [placeholder]="placeholder"
+  [disabled]="disabled"
+  [readonly]="readonly"
+  [required]="required"
+  [name]="name"
+  [maxLength]="maxLength"
+  [minLength]="minLength"
+  [autocomplete]="autocomplete"
+  [class]="classInput"
+  formControlName="text"
+/>

--- a/src/app/shared/input/input.component.html
+++ b/src/app/shared/input/input.component.html
@@ -10,5 +10,5 @@
   [minLength]="minLength"
   [autocomplete]="autocomplete"
   [class]="classInput"
-  formControlName="text"
+  (input)="onInput($event)"
 />

--- a/src/app/shared/input/input.component.ts
+++ b/src/app/shared/input/input.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-input',
+  imports: [],
+  templateUrl: './input.component.html',
+  styleUrl: './input.component.scss',
+})
+export class InputComponent {
+
+}

--- a/src/app/shared/input/input.component.ts
+++ b/src/app/shared/input/input.component.ts
@@ -1,21 +1,27 @@
-import { Component, input, Input } from "@angular/core";
+import { Component, EventEmitter, input, Input, Output } from "@angular/core";
 import { InputTextModule } from "primeng/inputtext";
 
 @Component({
-  selector: 'app-input',
-  imports: [InputTextModule],
-  templateUrl: './input.component.html',
-  styleUrl: './input.component.scss',
+	selector: "app-input",
+	imports: [InputTextModule],
+	templateUrl: "./input.component.html",
+	styleUrl: "./input.component.scss",
 })
 export class InputComponent {
-  @Input() type: string = 'text';
-  @Input() placeholder: string = '';
-  @Input() disabled: boolean = false;
-  @Input() readonly?: boolean;
-  @Input() required?: boolean;
-  @Input() name?: string;
-  @Input() maxLength: number = 10;
-  @Input() minLength?: number;
-  @Input() autocomplete?: string;
-  @Input() classInput: string = '';
+	@Input() type: string = "text";
+	@Input() placeholder: string = "";
+	@Input() disabled: boolean = false;
+	@Input() readonly?: boolean;
+	@Input() required?: boolean;
+	@Input() name?: string;
+	@Input() maxLength: number = 10;
+	@Input() minLength?: number;
+	@Input() autocomplete?: string;
+	@Input() classInput: string = "";
+
+	@Output() valueChange = new EventEmitter<any>();
+	onInput(event: Event) {
+		const value = (event.target as HTMLInputElement).value;
+		this.valueChange.emit(value);
+	}
 }

--- a/src/app/shared/input/input.component.ts
+++ b/src/app/shared/input/input.component.ts
@@ -1,11 +1,21 @@
-import { Component } from '@angular/core';
+import { Component, input, Input } from "@angular/core";
+import { InputTextModule } from "primeng/inputtext";
 
 @Component({
   selector: 'app-input',
-  imports: [],
+  imports: [InputTextModule],
   templateUrl: './input.component.html',
   styleUrl: './input.component.scss',
 })
 export class InputComponent {
-
+  @Input() type: string = 'text';
+  @Input() placeholder: string = '';
+  @Input() disabled: boolean = false;
+  @Input() readonly?: boolean;
+  @Input() required?: boolean;
+  @Input() name?: string;
+  @Input() maxLength: number = 10;
+  @Input() minLength?: number;
+  @Input() autocomplete?: string;
+  @Input() classInput: string = '';
 }


### PR DESCRIPTION
Este PR agrega un componente de Input reutilizable que permite:
Configurar tipo (`text`, `email`, `number`, etc.)
- Usar placeholder, label, name, maxlength, etc.
- Emitir cambios vía `@Output()`
- Estilo personalizable vía clases externas
![image](https://github.com/user-attachments/assets/e5326f0e-a222-4dae-9a97-3b08c6d13b90)

